### PR TITLE
Add ViewModel to prevent override of Block constructor

### DIFF
--- a/Block/Product/Gallery.php
+++ b/Block/Product/Gallery.php
@@ -3,48 +3,18 @@
  * Copyright © Rob Aimes - https://aimes.dev
  */
 
+declare(strict_types=1);
+
 namespace Aimes\Notorama\Block\Product;
 
-use Magento\Catalog\Block\Product\Context;
 use Magento\Catalog\Block\Product\View\Gallery as MagentoGallery;
-use Magento\Catalog\Model\Product\Gallery\ImagesConfigFactoryInterface;
-use Magento\Catalog\Model\Product\Image\UrlBuilder;
-use Magento\Framework\Json\EncoderInterface;
-use Magento\Framework\Serialize\Serializer\Json as JsonEncoder;
-use Magento\Framework\Stdlib\ArrayUtils;
 
+/**
+ * Class Gallery
+ * @package Aimes\Notorama\Block\Product
+ */
 class Gallery extends MagentoGallery
 {
-    /**
-     * @var JsonEncoder
-     */
-    protected $encoder;
-
-    /**
-     * Gallery constructor.
-     * @param Context $context
-     * @param ArrayUtils $arrayUtils
-     * @param EncoderInterface $jsonEncoder
-     * @param JsonEncoder $encoder
-     * @param array $data
-     * @param ImagesConfigFactoryInterface|null $imagesConfigFactory
-     * @param array $galleryImagesConfig
-     * @param UrlBuilder|null $urlBuilder
-     */
-    public function __construct(
-        Context $context,
-        ArrayUtils $arrayUtils,
-        EncoderInterface $jsonEncoder,
-        JsonEncoder $encoder,
-        array $data = [],
-        ImagesConfigFactoryInterface $imagesConfigFactory = null,
-        array $galleryImagesConfig = [],
-        UrlBuilder $urlBuilder = null
-    ) {
-        parent::__construct($context, $arrayUtils, $jsonEncoder, $data, $imagesConfigFactory, $galleryImagesConfig, $urlBuilder);
-        $this->encoder = $encoder;
-    }
-
     /**
      * @return 0|array
      */
@@ -67,15 +37,5 @@ class Gallery extends MagentoGallery
     public function getPlaceholderImageCaption()
     {
         return $this->getGalleryImages()->getFirstItem()->getData('label');
-    }
-
-    /**
-     * @return string
-     */
-    public function getJsConfig() : string
-    {
-        return $this->encoder->serialize([
-           'initialImages' => $this->getGalleryImagesJson()
-        ]);
     }
 }

--- a/ViewModel/Product/Gallery.php
+++ b/ViewModel/Product/Gallery.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © Rob Aimes - https://aimes.dev
+ */
+
+declare(strict_types=1);
+
+namespace Aimes\Notorama\ViewModel\Product;
+
+use Magento\Framework\Serialize\Serializer\Json as JsonEncoder;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+/**
+ * Class Gallery
+ * @package Aimes\Notorama\ViewModel\Product
+ */
+class Gallery implements ArgumentInterface
+{
+    /**
+     * @var JsonEncoder
+     */
+    private $encoder;
+
+    /**
+     * Gallery constructor.
+     * @param JsonEncoder $encoder
+     */
+    public function __construct(
+        JsonEncoder $encoder
+    ) {
+        $this->encoder = $encoder;
+    }
+
+    /**
+     * @param string $initialImagesJson
+     * @return string
+     */
+    public function getJsConfig(string $initialImagesJson) : string
+    {
+        return $this->encoder->serialize([
+            'initialImages' => $initialImagesJson
+        ]);
+    }
+}

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -24,7 +24,9 @@
 
         <referenceContainer name="product.info.media">
             <block name="notorama.gallery" class="Aimes\Notorama\Block\Product\Gallery" template="Aimes_Notorama::product/gallery.phtml">
-                <!-- Insert options -->
+                <arguments>
+                    <argument name="gallery_view_model" xsi:type="object">Aimes\Notorama\ViewModel\Product\Gallery</argument>
+                </arguments>
             </block>
         </referenceContainer>
 

--- a/view/frontend/templates/product/gallery.phtml
+++ b/view/frontend/templates/product/gallery.phtml
@@ -7,9 +7,12 @@
  * Product media data template
  *
  * @var $block \Aimes\Notorama\Block\Product\Gallery
+ * @var $galleryViewModel \Aimes\Notorama\viewModel\Product\Gallery
  */
+$galleryViewModel = $block->getGalleryViewModel();
+$jsConfig = $galleryViewModel->getJsConfig($block->getGalleryImagesJson());
 ?>
-<div id="notorama-gallery" class="notorama loading" data-mage-init='{"notorama": <?= $block->getJsConfig() ?>}'>
+<div id="notorama-gallery" class="notorama loading" data-mage-init='{"notorama": <?= $jsConfig ?>}'>
     <div id="gallery-placeholder" class="gallery-placeholder _block-content-loading" data-gallery-role="gallery-placeholder">
         <div class="notorama-view-wrapper">
             <div id="notorama-viewer" class="notorama-gallery-view">


### PR DESCRIPTION
The Block class that you added is "expensive", because it overrides the parent constructor and therefore introduces a ton of dependencies, simply to add a new dependency (the encoder). This PR adds a ViewModel, as supported in Magento since version 2.2, so that there is a separate clean class (the ViewModel) for that dependency instead.