### PR TITLE
Remove PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
   ],
   "require": {
     "magento/framework": "^101.1|^102.0",
-    "magento/module-catalog": "^101.0|^102.0|^103.0",
-    "php": "~7.0.0"
+    "magento/module-catalog": "^101.0|^102.0|^103.0"
   },
   "autoload": {
     "files": [ "registration.php" ],


### PR DESCRIPTION
Remove PHP requirement because it is best practice to only have a dep with Magento itself